### PR TITLE
fix: Prevent crash on sign-in due to missing user avatar

### DIFF
--- a/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AuthSignInActivity.kt
+++ b/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AuthSignInActivity.kt
@@ -105,10 +105,11 @@ class AuthSignInActivity : AppCompatActivity() {
             val photo = PeopleManager.getOwnerAvatarBitmap(this@AuthSignInActivity, account.name, false)
             if (photo == null) {
                 lifecycleScope.launchWhenStarted {
-                    val bitmap = withContext(Dispatchers.IO) {
+                    withContext(Dispatchers.IO) {
                         PeopleManager.getOwnerAvatarBitmap(this@AuthSignInActivity, account.name, true)
+                    }?.let {
+                        updateAction(photoView, it)
                     }
-                    updateAction(photoView, bitmap)
                 }
             }
             val displayName = getDisplayName(account)


### PR DESCRIPTION
Should address this user-reported crash: https://github.com/hoo-dles/morphe-patches/issues/301#issuecomment-4322005941

Looks like the same fix is already in upstream: https://github.com/microg/GmsCore/blob/352f2d72fa52c6c3c4fdd79d575a071a0da72ad1/play-services-core/src/main/kotlin/org/microg/gms/auth/signin/AuthSignInActivity.kt#L106